### PR TITLE
Bugfix on uniqueUsernameGenerator

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -91,18 +91,14 @@ export function uniqueUsernameGenerator(config: Config): string {
       "the 'dictionary' field empty in the config object",
     );
   } else {
+    const fromDictRander = (i: number) => config.dictionaries[i][getRandomInt(0, config.dictionaries[i].length - 1)];
     const dictionariesLength = config.dictionaries.length;
+    const separator = config.separator || "";
     let name = "";
     for (let i = 0; i < dictionariesLength; i++) {
-      if (name && config.separator) {
-        if (config.separator) {
-          name = name + config.separator + config.dictionaries[i][Math.floor(getRandomInt(0, 1) * config.dictionaries[i].length)];
-        } else {
-          name = name + config.dictionaries[i][Math.floor(getRandomInt(0, 1) * config.dictionaries[i].length)];
-        }
-      } else {
-        name = config.dictionaries[i][Math.floor(getRandomInt(0, 1) * config.dictionaries[i].length)];
-      }
+      const next = fromDictRander(i);
+      if (!name) { name = next; }
+      else { name += separator + next; }
     }
 
     let username = name + randomNumber(config.randomDigits);

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { generateFromEmail } from "../src/index";
+import { adjectives, nouns, generateFromEmail, uniqueUsernameGenerator } from "../src/index";
 import { expect } from "chai";
 
 describe("generate-unique-username-from-email unit tests", (): void => {
@@ -57,5 +57,47 @@ describe("generate-unique-username-from-email unit tests", (): void => {
   it("generating from email with special character in the name and adding six random digit", (): void => {
     const actual: string = generateFromEmail("lakshmi.narayan@example.com", 6);
     expect(actual.slice(0, -6)).is.equal("lakshminarayan");
+  });
+});
+
+describe("generate-unique-username-uniqueUsernameGenerator unit tests", (): void => {
+  it("uniqueUsernameGenerator uses all dicts w separator", (): void => {
+    const actual: string = uniqueUsernameGenerator({
+      dictionaries: [['q'], ['a']],
+      separator: '-'
+    });
+    expect(actual).is.equal('q-a');
+  });
+
+  it("uniqueUsernameGenerator uses all dicts wo separator", (): void => {
+    const actual: string = uniqueUsernameGenerator({
+      dictionaries: [['q'], ['a']]
+    });
+    expect(actual).is.equal('qa');
+  });
+  it("uniqueUsernameGenerator style UPPERCASE", (): void => {
+    const actual: string = uniqueUsernameGenerator({
+      dictionaries: [['q'], ['a']],
+      style: 'upperCase'
+    });
+    expect(actual).is.equal('QA');
+  });
+  it("uniqueUsernameGenerator style lowercase", (): void => {
+    const actual: string = uniqueUsernameGenerator({
+      dictionaries: [['Q'], ['A']],
+      style: 'lowerCase'
+    });
+    expect(actual).is.equal('qa');
+  });
+  it("uniqueUsernameGenerator style capital", (): void => {
+    const actual: string = uniqueUsernameGenerator({
+      dictionaries: [['q'], ['A']],
+      style: 'capital'
+    });
+    expect(actual).is.equal('Qa');
+  });
+  it("uniqueUsernameGenerator works w config w default dictionaries only", (): void => {
+    const actual: string = uniqueUsernameGenerator({ dictionaries: [adjectives, nouns] });
+    expect(actual).not.contains('-');
   });
 });

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -63,41 +63,41 @@ describe("generate-unique-username-from-email unit tests", (): void => {
 describe("generate-unique-username-uniqueUsernameGenerator unit tests", (): void => {
   it("uniqueUsernameGenerator uses all dicts w separator", (): void => {
     const actual: string = uniqueUsernameGenerator({
-      dictionaries: [['q'], ['a']],
-      separator: '-'
+      dictionaries: [["q"], ["a"]],
+      separator: "-"
     });
-    expect(actual).is.equal('q-a');
+    expect(actual).is.equal("q-a");
   });
 
   it("uniqueUsernameGenerator uses all dicts wo separator", (): void => {
     const actual: string = uniqueUsernameGenerator({
-      dictionaries: [['q'], ['a']]
+      dictionaries: [["q"], ["a"]]
     });
-    expect(actual).is.equal('qa');
+    expect(actual).is.equal("qa");
   });
   it("uniqueUsernameGenerator style UPPERCASE", (): void => {
     const actual: string = uniqueUsernameGenerator({
-      dictionaries: [['q'], ['a']],
-      style: 'upperCase'
+      dictionaries: [["q"], ["a"]],
+      style: "upperCase"
     });
-    expect(actual).is.equal('QA');
+    expect(actual).is.equal("QA");
   });
   it("uniqueUsernameGenerator style lowercase", (): void => {
     const actual: string = uniqueUsernameGenerator({
-      dictionaries: [['Q'], ['A']],
-      style: 'lowerCase'
+      dictionaries: [["Q"], ["A"]],
+      style: "lowerCase"
     });
-    expect(actual).is.equal('qa');
+    expect(actual).is.equal("qa");
   });
   it("uniqueUsernameGenerator style capital", (): void => {
     const actual: string = uniqueUsernameGenerator({
-      dictionaries: [['q'], ['A']],
-      style: 'capital'
+      dictionaries: [["q"], ["A"]],
+      style: "capital"
     });
-    expect(actual).is.equal('Qa');
+    expect(actual).is.equal("Qa");
   });
   it("uniqueUsernameGenerator works w config w default dictionaries only", (): void => {
     const actual: string = uniqueUsernameGenerator({ dictionaries: [adjectives, nouns] });
-    expect(actual).not.contains('-');
+    expect(actual).not.contains("-");
   });
 });


### PR DESCRIPTION
Fixed multiple bugs in uniqueUsernameGenerator
* random misuse bug ([141c368](https://github.com/subhamg/unique-username-generator/commit/141c3685df1a6f7c0bc37d9e09f636aa4419f273)) - Math.random() is not interchangeable with getRandomInt(0, 1), resulting in taking either the first element in the array or undefined at array[array.length]. Correct usage in this case is taking a random int in the range [0, array.length-1].
* separator bug - not supplying a separator results in using a single dictionary. Changed conditions to account for no separator and use empty string instead.