### PR TITLE
uniqueUsernameGenerator fixes and enhancements

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -155,6 +155,8 @@ export function uniqueUsernameGenerator(config: Config): string {
     const fromDictRander = (i: number) => usableDictionaries[i][randInt(0, usableDictionaries[i].length - 1)];
     const dictionariesLength = usableDictionaries.length;
     const separator = config.separator || "";
+    const maxLength = config.length || 15;
+
     // Template-based assembly
     let username: string;
     let alreadyFormatted = false;
@@ -175,12 +177,7 @@ export function uniqueUsernameGenerator(config: Config): string {
       username = formatUsername(username, config.style ?? "lowerCase", separator);
     }
 
-    if (config.length) {
-      return username.substring(0, config.length);
-    } else {
-      return username.substring(0, 15);
-    }
-
+    return username.substring(0, maxLength);
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,31 +70,11 @@ export function generateMany(options: GenerateManyOptions): string[] {
 }
 
 const randomNumber = (maxNumber: number | undefined) => {
-  let randomNumberString;
-  switch (maxNumber) {
-    case 1:
-      randomNumberString = Math.floor(getRandomInt(1, 9)).toString();
-      break;
-    case 2:
-      randomNumberString = Math.floor(getRandomInt(10, 90)).toString();
-      break;
-    case 3:
-      randomNumberString = Math.floor(getRandomInt(100, 900)).toString();
-      break;
-    case 4:
-      randomNumberString = Math.floor(getRandomInt(1000, 9000)).toString();
-      break;
-    case 5:
-      randomNumberString = Math.floor(getRandomInt(10000, 90000)).toString();
-      break;
-    case 6:
-      randomNumberString = Math.floor(getRandomInt(100000, 900000)).toString();
-      break;
-    default:
-      randomNumberString = "";
-      break;
+  if (!maxNumber || maxNumber < 1 || maxNumber > 6) { return ""; }
+  else {
+    const s = Math.pow(10, maxNumber - 1);
+    return Math.floor(getRandomInt(s, 10 * s - 1)).toString();
   }
-  return randomNumberString;
 };
 
 export function generateFromEmail(email: string, randomDigits?: number): string;

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -87,6 +87,20 @@ describe("generate-unique-username-uniqueUsernameGenerator unit tests", (): void
     });
     expect(actual).is.equal("qa");
   });
+  it("uniqueUsernameGenerator digits 1", (): void => {
+    const actual: string = uniqueUsernameGenerator({
+      dictionaries: [["q"], ["a"]],
+      randomDigits: 1
+    });
+    expect(actual).to.match(/qa[1-9]/);
+  });
+  it("uniqueUsernameGenerator digits 3", (): void => {
+    const actual: string = uniqueUsernameGenerator({
+      dictionaries: [["q"], ["a"]],
+      randomDigits: 3
+    });
+    expect(actual).to.match(/qa[1-9]\d{2}/);
+  });
   it("uniqueUsernameGenerator style UPPERCASE", (): void => {
     const actual: string = uniqueUsernameGenerator({
       dictionaries: [["q"], ["a"]],

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -87,6 +87,26 @@ describe("generate-unique-username-uniqueUsernameGenerator unit tests", (): void
     });
     expect(actual).is.equal("qa");
   });
+  it("uniqueUsernameGenerator length 1 trims 2 to 1", (): void => {
+    const actual: string = uniqueUsernameGenerator({
+      dictionaries: [["qa"]],
+      length: 1
+    });
+    expect(actual).is.equal("q");
+  });
+  it("uniqueUsernameGenerator length 3 leaves 2 unchanged", (): void => {
+    const actual: string = uniqueUsernameGenerator({
+      dictionaries: [["qa"]],
+      length: 3
+    });
+    expect(actual).is.equal("qa");
+  });
+  it("uniqueUsernameGenerator default length", (): void => {
+    const actual: string = uniqueUsernameGenerator({
+      dictionaries: [["qazwsxedcrfvtgby"]]
+    });
+    expect(actual).is.equal("qazwsxedcrfvtgb");
+  });
   it("uniqueUsernameGenerator digits 1", (): void => {
     const actual: string = uniqueUsernameGenerator({
       dictionaries: [["q"], ["a"]],


### PR DESCRIPTION
Multiple changes:
* Simplified uniqueUsernameGenerator length and added tests
* (BREAKING) Fixed a bug in randomNumber, missing the last stretch (e.g. [91-99]). Simplified randomNumber
* ~Added new styles camelCase and pascalCase~
* ~(BREAKING) Changed uniqueUsernameGenerator default behaviour to filter all dictionaries out of entries containing the separator. If a dictionary turns empty, throw an error.~
* ~Removed a faulty test case. The test wrongly assumed that the default dictionaries contain no dash '-'~