### PR TITLE
feat: allow to have prefix for usernames

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ const username = generateUsername("", 2, 19);
 console.log(username); // blossomlogistical73
 
 // With all parameters
-const username = generateUsername("-", 2, 20);
-console.log(username); // blossom-logistical73
+const username = generateUsername("-", 2, 20, 'unique.username');
+console.log(username); // unique.username-73
 ```
 
 ### Default dictionaries

--- a/README.md
+++ b/README.md
@@ -84,8 +84,8 @@ const username = generateUsername("", 2, 19);
 console.log(username); // blossomlogistical73
 
 // With all parameters
-const username = generateUsername("-", 2, 20, 'unique.username');
-console.log(username); // unique.username-73
+const username = generateUsername("-", 2, 20, 'unique username');
+console.log(username); // unique-username-73
 ```
 
 ### Default dictionaries

--- a/src/index.ts
+++ b/src/index.ts
@@ -64,10 +64,11 @@ export function generateFromEmail(
 export function generateUsername(
   separator?: string,
   randomDigits?: number,
-  length?: number
+  length?: number,
+  prefix?: string
 ): string {
   const noun = nouns[Math.floor(Math.random() * nouns.length)];
-  const adjective = adjectives[Math.floor(Math.random() * adjectives.length)];
+  const adjective = prefix || adjectives[Math.floor(Math.random() * adjectives.length)];
 
   let username;
   // Create unique username

--- a/src/index.ts
+++ b/src/index.ts
@@ -68,7 +68,7 @@ export function generateUsername(
   prefix?: string
 ): string {
   const noun = nouns[Math.floor(Math.random() * nouns.length)];
-  const adjective = prefix || adjectives[Math.floor(Math.random() * adjectives.length)];
+  const adjective = prefix ? prefix.replace(/\s{2,}/g, ' ').replace(/\s/g, separator ?? '').toLocaleLowerCase() : adjectives[Math.floor(Math.random() * adjectives.length)];
 
   let username;
   // Create unique username

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,4 +1,4 @@
-import { adjectives, nouns, generateFromEmail, uniqueUsernameGenerator } from "../src/index";
+import { adjectives, nouns, generateFromEmail, uniqueUsernameGenerator, generateUsername } from "../src/index";
 import { expect } from "chai";
 
 describe("generate-unique-username-from-email unit tests", (): void => {
@@ -101,3 +101,29 @@ describe("generate-unique-username-uniqueUsernameGenerator unit tests", (): void
     expect(actual).not.contains("-");
   });
 });
+
+describe("generate-unique-username unit tests", (): void => {
+  it("generating unique username", (): void => {
+    const actual: string = generateUsername();
+    expect(typeof actual).is.equal("string");
+    expect(actual).is.not.equal("");
+  });
+
+  it("generating unique username with separator", (): void => {
+    const actual: string = generateUsername("-");
+    expect(actual).is.contains("-");
+    expect(actual.split('-').length).is.greaterThan(1);
+  });
+  it("generating unique username with separator and no random number", (): void => {
+    const actual: string = generateUsername("-", 0);
+    expect(actual).to.not.match(/[0-9]/);
+  });
+  it("generating unique username with max length", (): void => {
+    const actual: string = generateUsername("-", 2, 5);
+    expect(actual).to.lengthOf(5)
+  });
+  it("generating unique username with max length and prefix", (): void => {
+    const actual: string = generateUsername("-", undefined, undefined, "unique username");
+    expect(actual).to.contain(`unique-username`)
+  });
+})


### PR DESCRIPTION
Recently, I was building a unique username generation for one of my project, and I came across this library. The issue I had is I wanted to generate a unique username, but I already had a prefix that I want to have which is not possible with the library, and I see a similar issue is posted here https://github.com/subhamg/unique-username-generator/issues/16. So, thought of putting it here.