### PR TITLE
feat: allow for prefixOnly

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -58,16 +58,17 @@ export function generateFromEmail(
   // Replace all special characters like "@ . _ ";
   const name = nameParts.replace(/[&/\\#,+()$~%._@'":*?<>{}]/g, "");
   // Create and return unique username
-  return name + randomNumber(randomDigits);
+  return generateUsername(undefined, randomDigits, undefined, name, true);
 }
 
 export function generateUsername(
   separator?: string,
   randomDigits?: number,
   length?: number,
-  prefix?: string
+  prefix?: string,
+  prefixOnly?: boolean
 ): string {
-  const noun = nouns[Math.floor(Math.random() * nouns.length)];
+  const noun = !prefixOnly ? nouns[Math.floor(Math.random() * nouns.length)] : "";
   const adjective = prefix ? prefix.replace(/\s{2,}/g, " ").replace(/\s/g, separator ?? "").toLocaleLowerCase() : adjectives[Math.floor(Math.random() * adjectives.length)];
 
   let username;
@@ -79,7 +80,12 @@ export function generateUsername(
   }
 
   if (length) {
-    return username.substring(0, length);
+    username = username.substring(0, length);
+  }
+
+  // strip trailing separator
+  if (separator && username.endsWith(separator)) {
+    username = username.slice(0, -separator.length);
   }
 
   return username;

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -120,10 +120,18 @@ describe("generate-unique-username unit tests", (): void => {
   });
   it("generating unique username with max length", (): void => {
     const actual: string = generateUsername("-", 2, 5);
-    expect(actual).to.lengthOf(5)
+    expect(actual).to.lengthOf(5);
   });
   it("generating unique username with max length and prefix", (): void => {
     const actual: string = generateUsername("-", undefined, undefined, "unique username");
-    expect(actual).to.contain(`unique-username`)
+    expect(actual).to.contain(`unique-username`);
+  });
+  it("generating unique username with prefix only", (): void => {
+    const actual: string = generateUsername("-", undefined, undefined, "unique username", true);
+    expect(actual).to.equal(`unique-username`);
+  });
+  it("generating unique username with random number and prefix only", (): void => {
+    const actual: string = generateUsername("-", 1, undefined, "unique username", true);
+    expect(actual).to.contain(`unique-username-`);
   });
 })


### PR DESCRIPTION
This just adds the ability to essentially not have a `noun` added if you don't want, and makes sure to strip the `separator` if it is trailing.

It also opts to use the base generate fn for easier modification and extension.